### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+Fyndmaskinen is a React SPA (Create React App) — a Swedish second-hand marketplace aggregator. It is a **frontend-only** repository; the backend GraphQL API (`api.fyndmaskinen.se`) and Auth0 are external services not included here.
+
+### Running the dev server
+```
+npm run dev   # starts react-scripts on port 3000
+```
+
+### Lint
+```
+npx eslint src/**/*.js --fix
+```
+The ESLint config is inline in `package.json`. The warning about React version not being specified is benign.
+
+### Tests
+```
+CI=true npx react-scripts test --watchAll=false
+```
+**Note:** `src/App.test.js` is a pre-existing failing test (uses deprecated React 17 `ReactDOM.render` API while the app uses React 18 `createRoot`). It is also listed in the ESLint ignore patterns, confirming it is known to be outdated. Do not attempt to fix it unless explicitly asked.
+
+### Build
+```
+npm run build
+```
+
+### Key caveats
+- **Backend API:** When running on `localhost`, `src/index.js` sets `window.API_HOSTNAME` to `http://192.168.1.218:4080` (a local network address). This API is not available in cloud environments. The app will load and be interactive, but search results and data will not populate. This is expected.
+- **Auth0:** Authentication requires the external Auth0 tenant (`fyndmaskinen.eu.auth0.com`). Login flows will redirect externally but may not work without proper Auth0 configuration for the current origin.
+- **Node version:** `package.json` specifies `engines.node: "^20.0.0"`. Node 22 works fine despite the engine warning during `npm install`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up the development environment for Fyndmaskinen and added `AGENTS.md` with Cursor Cloud specific instructions for future agents.

## What was done

- Verified Node.js compatibility (v22 works despite `engines: ^20.0.0`)
- Installed npm dependencies
- Ran ESLint lint checks (passes with benign warning)
- Ran automated tests (pre-existing failure in `App.test.js` — uses deprecated React 17 API)
- Built production bundle successfully
- Started dev server (`npm run dev`) and verified it serves on port 3000
- Performed a hello-world search interaction demonstrating the app is functional

## Demo

[fyndmaskinen_search_demo.mp4](https://cursor.com/agents/bc-c5ec3468-c67f-46d5-a6dc-e72812c25988/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffyndmaskinen_search_demo.mp4)

Homepage loaded with search bar and marketplace filters:

[Fyndmaskinen homepage](https://cursor.com/agents/bc-c5ec3468-c67f-46d5-a6dc-e72812c25988/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_loaded.webp)

Search for "stol" submitted and results page rendered:

[Search results page](https://cursor.com/agents/bc-c5ec3468-c67f-46d5-a6dc-e72812c25988/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_results.webp)

## Files changed

- `AGENTS.md` — New file with Cursor Cloud specific development instructions covering dev server, lint, tests, build, and key caveats about the external backend API and Auth0.

## Update script

```
npm install
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5ec3468-c67f-46d5-a6dc-e72812c25988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5ec3468-c67f-46d5-a6dc-e72812c25988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

